### PR TITLE
Implement passing an external moment instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,16 @@ const unitsAsc = _.sortBy(units, function (unit) {
 });
 const unitsDesc = unitsAsc.reverse();
 
-/* This is a simplified version of elasticsearch's date parser */
-function parse(text, roundUp) {
+/*
+ * This is a simplified version of elasticsearch's date parser.
+ * If you pass in a momentjs instance as the third parameter the calculation
+ * will be done using this (and its locale settings) instead of the one bundled
+ * with this library.
+ */
+function parse(text, roundUp, momentInstance = moment) {
   if (!text) return undefined;
-  if (moment.isMoment(text)) return text;
-  if (_.isDate(text)) return moment(text);
+  if (momentInstance.isMoment(text)) return text;
+  if (_.isDate(text)) return momentInstance(text);
 
   let time;
   let mathString = '';
@@ -19,7 +24,7 @@ function parse(text, roundUp) {
   let parseString;
 
   if (text.substring(0, 3) === 'now') {
-    time = moment();
+    time = momentInstance();
     mathString = text.substring('now'.length);
   } else {
     index = text.indexOf('||');
@@ -31,7 +36,7 @@ function parse(text, roundUp) {
       mathString = text.substring(index + 2);
     }
     // We're going to just require ISO8601 timestamps, k?
-    time = moment(parseString);
+    time = momentInstance(parseString);
   }
 
   if (!mathString.length) {

--- a/test/index.js
+++ b/test/index.js
@@ -225,4 +225,58 @@ describe('dateMath', function () {
       expect(val.isoWeekday()).to.eql(3 - 1);
     });
   });
+
+  describe('used momentjs instance', function () {
+    it('should use the default moment instance if parameter not specified', function () {
+      const momentSpy = sinon.spy(moment, 'isMoment');
+      dateMath.parse('now');
+      expect(momentSpy.called).to.be(true);
+      momentSpy.restore();
+    });
+
+    it('should not use default moment instance if parameter is specified', function () {
+      const m = momentClone();
+      const momentSpy = sinon.spy(moment, 'isMoment');
+      const cloneSpy = sinon.spy(m, 'isMoment');
+      dateMath.parse('now', false, m);
+      expect(momentSpy.called).to.be(false);
+      expect(cloneSpy.called).to.be(true);
+      momentSpy.restore();
+      cloneSpy.restore();
+    });
+
+    it('should work with multiple different instances', function () {
+      const m1 = momentClone();
+      const m2 = momentClone();
+      const m1Spy = sinon.spy(m1, 'isMoment');
+      const m2Spy = sinon.spy(m2, 'isMoment');
+      dateMath.parse('now', false, m1);
+      expect(m1Spy.called).to.be(true);
+      expect(m2Spy.called).to.be(false);
+      m1Spy.reset();
+      m2Spy.reset();
+      dateMath.parse('now', false, m2);
+      expect(m1Spy.called).to.be(false);
+      expect(m2Spy.called).to.be(true);
+      m1Spy.restore();
+      m2Spy.restore();
+    });
+
+    it('should use global instance after passing an instance', function () {
+      const m = momentClone();
+      const momentSpy = sinon.spy(moment, 'isMoment');
+      const cloneSpy = sinon.spy(m, 'isMoment');
+      dateMath.parse('now', false, m);
+      expect(momentSpy.called).to.be(false);
+      expect(cloneSpy.called).to.be(true);
+      momentSpy.reset();
+      cloneSpy.reset();
+      dateMath.parse('now');
+      expect(momentSpy.called).to.be(true);
+      expect(cloneSpy.called).to.be(false);
+      momentSpy.restore();
+      cloneSpy.restore();
+    });
+  });
+
 });

--- a/test/index.js
+++ b/test/index.js
@@ -221,7 +221,7 @@ describe('dateMath', function () {
       });
       const val = dateMath.parse('now-1w/w', true, m);
       // The end of the range (rounding up) should be the last day of the week (so one day before)
-      // our start of the week, that's why 2 - 1
+      // our start of the week, that's why 3 - 1
       expect(val.isoWeekday()).to.eql(3 - 1);
     });
   });


### PR DESCRIPTION
This will be needed to implement [kibana#14495](https://github.com/elastic/kibana/issues/14495).

It allows passing in an external momentjs instance, that will be used instead of the bundled one. That way we can pass in the instance from Kibana, that actually has the modified locale, with the start of the week setting configured by the `dateFormat:dow` advanced setting in Kibana.

If you don't specify a third parameter everything works the very same way as before.