### PR TITLE
Chore: Remove lodash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 lib
 node_modules
 npm-debug.log
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run build && mocha --compilers js:babel-core/register",
     "build": "babel src --out-dir lib",
-    "prepublish": "npm run test"
+    "prepublishOnly": "npm run test"
   },
   "author": "Elastic",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "sinon": "~1.17.3"
   },
   "dependencies": {
-    "lodash": "~3.10.1",
     "moment": "~2.13.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
-import _ from 'lodash';
 import moment from 'moment';
 
 const units = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'ms'];
-const unitsAsc = _.sortBy(units, function (unit) {
-  return moment.duration(1, unit).valueOf();
-});
+const unitsAsc = units.sort((prev, val) => prev - moment.duration(1, val).valueOf());
 const unitsDesc = unitsAsc.reverse();
+
+const isDate = d => toString.call(d) === '[object Date]';
 
 /*
  * This is a simplified version of elasticsearch's date parser.
@@ -16,7 +15,7 @@ const unitsDesc = unitsAsc.reverse();
 function parse(text, roundUp, momentInstance = moment) {
   if (!text) return undefined;
   if (momentInstance.isMoment(text)) return text;
-  if (_.isDate(text)) return momentInstance(text);
+  if (isDate(text)) return momentInstance(text);
 
   let time;
   let mathString = '';
@@ -99,7 +98,7 @@ function parseDateMath(mathString, time, roundUp) {
       else break;
     }
 
-    if (!_.contains(units, unit)) {
+    if (units.indexOf(unit) === -1) {
       return;
     } else {
       if (type === 0) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 import dateMath from '../lib/index';
-import _ from 'lodash';
 import moment from 'moment';
 import sinon from 'sinon';
 import expect from 'expect.js';
@@ -101,8 +100,8 @@ describe('dateMath', function () {
       clock.restore();
     });
 
-    _.each([5, 12, 247], function (len) {
-      _.each(spans, function (span) {
+    [5, 12, 247].forEach((len) => {
+      spans.forEach((span) => {
         const nowEx = `now-${len}${span}`;
         const thenEx =  `${anchor}||-${len}${span}`;
 
@@ -131,8 +130,8 @@ describe('dateMath', function () {
       clock.restore();
     });
 
-    _.each([5, 12, 247], function (len) {
-      _.each(spans, function (span) {
+    [5, 12, 247].forEach((len) => {
+      spans.forEach((span) => {
         const nowEx = `now+${len}${span}`;
         const thenEx =  `${anchor}||+${len}${span}`;
 
@@ -159,7 +158,7 @@ describe('dateMath', function () {
       clock.restore();
     });
 
-    _.each(spans, function (span) {
+    spans.forEach((span) => {
       it('should round now to the beginning of the ' + span, function () {
         expect(dateMath.parse('now/' + span).format(format)).to.eql(now.startOf(span).format(format));
       });


### PR DESCRIPTION
It's more trouble than it's worth. 

Everything we were using it for can be done with native javascript. The only exception is `isDate`, which really only needs to be a very simple check. 