### PR TITLE
Adding forceNow parameter that we can use to emulate a different time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ const unitsDesc = unitsAsc.reverse();
 
 const isDate = d => toString.call(d) === '[object Date]';
 
+const isValidDate = d => isDate(d) && !isNaN(d.valueOf());
+
 /*
  * This is a simplified version of elasticsearch's date parser.
  * If you pass in a momentjs instance as the third parameter the calculation
@@ -16,6 +18,7 @@ function parse(text, { roundUp = false, momentInstance = moment, forceNow } = {}
   if (!text) return undefined;
   if (momentInstance.isMoment(text)) return text;
   if (isDate(text)) return momentInstance(text);
+  if (forceNow !== undefined && !isValidDate(forceNow)) throw new Error('forceNow must be a valid Date');
 
   let time;
   let mathString = '';

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const isDate = d => toString.call(d) === '[object Date]';
  * will be done using this (and its locale settings) instead of the one bundled
  * with this library.
  */
-function parse(text, roundUp, momentInstance = moment) {
+function parse(text, roundUp, momentInstance = moment, forceNow = undefined) {
   if (!text) return undefined;
   if (momentInstance.isMoment(text)) return text;
   if (isDate(text)) return momentInstance(text);
@@ -23,7 +23,7 @@ function parse(text, roundUp, momentInstance = moment) {
   let parseString;
 
   if (text.substring(0, 3) === 'now') {
-    time = momentInstance();
+    time = momentInstance(forceNow);
     mathString = text.substring('now'.length);
   } else {
     index = text.indexOf('||');

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const isDate = d => toString.call(d) === '[object Date]';
  * will be done using this (and its locale settings) instead of the one bundled
  * with this library.
  */
-function parse(text, roundUp, momentInstance = moment, forceNow = undefined) {
+function parse(text, { roundUp = false, momentInstance = moment, forceNow } = {}) {
   if (!text) return undefined;
   if (momentInstance.isMoment(text)) return text;
   if (isDate(text)) return momentInstance(text);

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,7 @@ describe('dateMath', function () {
   // Test each of these intervals when testing relative time
   const spans = ['s', 'm', 'h', 'd', 'w', 'M', 'y', 'ms'];
   const anchor =  '2014-01-01T06:06:06.666Z';
+  const anchoredDate = new Date(Date.parse(anchor));
   const unix = moment(anchor).valueOf();
   const format = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
   let clock;
@@ -47,6 +48,20 @@ describe('dateMath', function () {
       expect(dateMath.parse('now-0')).to.be(undefined);
       expect(dateMath.parse('now-00')).to.be(undefined);
       expect(dateMath.parse('now-000')).to.be(undefined);
+    });
+
+    describe('forceNow', function () {
+      it('should throw an Error if passed a string', function () {
+        expect(() => dateMath.parse('now', { forceNow: '2000-01-01T00:00:00.000Z' })).to.throwError();
+      });
+
+      it('should throw an Error if passed a moment', function () {
+        expect(() => dateMath.parse('now', { forceNow: moment() })).to.throwError();
+      });
+
+      it('should throw an Error if passed an invalid date', function () {
+        expect(() => dateMath.parse('now', { forceNow: new Date('foobar') })).to.throwError();
+      });
     });
 
   });
@@ -86,7 +101,7 @@ describe('dateMath', function () {
     });
 
     it(`should use the forceNow parameter when parsing now`, function () {
-      expect(dateMath.parse('now', { forceNow: mmnt }).format(format)).to.eql(mmnt.format(format));
+      expect(dateMath.parse('now', { forceNow: anchoredDate }).valueOf()).to.eql(unix);
     });
   });
 
@@ -118,7 +133,7 @@ describe('dateMath', function () {
         });
 
         it('should return ' + len + span + ' before forceNow', function () {
-          expect(dateMath.parse(nowEx, { forceNow: anchored }).format(format)).to.eql(anchored.subtract(len, span).format(format));
+          expect(dateMath.parse(nowEx, { forceNow: anchoredDate }).valueOf()).to.eql(anchored.subtract(len, span).valueOf());
         });
       });
     });
@@ -152,7 +167,7 @@ describe('dateMath', function () {
         });
 
         it('should return ' + len + span + ' after forceNow', function () {
-          expect(dateMath.parse(nowEx, { forceNow: anchored }).format(format)).to.eql(anchored.add(len, span).format(format));
+          expect(dateMath.parse(nowEx, { forceNow: anchoredDate }).valueOf()).to.eql(anchored.add(len, span).valueOf());
         });
       });
     });
@@ -178,7 +193,7 @@ describe('dateMath', function () {
       });
 
       it(`should round now to the beginning of forceNow's ` + span, function () {
-        expect(dateMath.parse('now/' + span, { forceNow: anchored }).format(format)).to.eql(anchored.startOf(span).format(format));
+        expect(dateMath.parse('now/' + span, { forceNow: anchoredDate }).valueOf()).to.eql(anchored.startOf(span).valueOf());
       });
 
       it('should round now to the end of the ' + span, function () {
@@ -186,7 +201,7 @@ describe('dateMath', function () {
       });
 
       it(`should round now to the end of forceNow's ` + span, function () {
-        expect(dateMath.parse('now/' + span, { roundUp: true, forceNow: anchored }).format(format)).to.eql(anchored.endOf(span).format(format));
+        expect(dateMath.parse('now/' + span, { roundUp: true, forceNow: anchoredDate }).valueOf()).to.eql(anchored.endOf(span).valueOf());
       });
     });
   });
@@ -249,8 +264,8 @@ describe('dateMath', function () {
     });
 
     it('should round relative to forceNow', function () {
-      const val = dateMath.parse('now-0s/s', { forceNow: anchored }).format(format);
-      expect(val).to.eql(anchored.startOf('s').format(format));
+      const val = dateMath.parse('now-0s/s', { forceNow: anchoredDate }).valueOf();
+      expect(val).to.eql(anchored.startOf('s').valueOf());
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -86,7 +86,7 @@ describe('dateMath', function () {
     });
 
     it(`should use the forceNow parameter when parsing now`, function () {
-      expect(dateMath.parse('now', undefined, undefined, mmnt).format(format)).to.eql(mmnt.format(format));
+      expect(dateMath.parse('now', { forceNow: mmnt }).format(format)).to.eql(mmnt.format(format));
     });
   });
 
@@ -118,7 +118,7 @@ describe('dateMath', function () {
         });
 
         it('should return ' + len + span + ' before forceNow', function () {
-          expect(dateMath.parse(nowEx, undefined, undefined, anchored).format(format)).to.eql(anchored.subtract(len, span).format(format));
+          expect(dateMath.parse(nowEx, { forceNow: anchored }).format(format)).to.eql(anchored.subtract(len, span).format(format));
         });
       });
     });
@@ -152,7 +152,7 @@ describe('dateMath', function () {
         });
 
         it('should return ' + len + span + ' after forceNow', function () {
-          expect(dateMath.parse(nowEx, undefined, undefined, anchored).format(format)).to.eql(anchored.add(len, span).format(format));
+          expect(dateMath.parse(nowEx, { forceNow: anchored }).format(format)).to.eql(anchored.add(len, span).format(format));
         });
       });
     });
@@ -178,15 +178,15 @@ describe('dateMath', function () {
       });
 
       it(`should round now to the beginning of forceNow's ` + span, function () {
-        expect(dateMath.parse('now/' + span, undefined, undefined, anchored).format(format)).to.eql(anchored.startOf(span).format(format));
+        expect(dateMath.parse('now/' + span, { forceNow: anchored }).format(format)).to.eql(anchored.startOf(span).format(format));
       });
 
       it('should round now to the end of the ' + span, function () {
-        expect(dateMath.parse('now/' + span, true).format(format)).to.eql(now.endOf(span).format(format));
+        expect(dateMath.parse('now/' + span, { roundUp: true }).format(format)).to.eql(now.endOf(span).format(format));
       });
 
       it(`should round now to the end of forceNow's ` + span, function () {
-        expect(dateMath.parse('now/' + span, true, undefined, anchored).format(format)).to.eql(anchored.endOf(span).format(format));
+        expect(dateMath.parse('now/' + span, { roundUp: true, forceNow: anchored }).format(format)).to.eql(anchored.endOf(span).format(format));
       });
     });
   });
@@ -232,7 +232,7 @@ describe('dateMath', function () {
       m.defineLocale('x-test', {
         week: { dow: 2 }
       });
-      const val = dateMath.parse('now-1w/w', false, m);
+      const val = dateMath.parse('now-1w/w', { momentInstance: m });
       expect(val.isoWeekday()).to.eql(2);
     });
 
@@ -242,14 +242,14 @@ describe('dateMath', function () {
       m.defineLocale('x-test', {
         week: { dow: 3 }
       });
-      const val = dateMath.parse('now-1w/w', true, m);
+      const val = dateMath.parse('now-1w/w', { roundUp: true, momentInstance: m });
       // The end of the range (rounding up) should be the last day of the week (so one day before)
       // our start of the week, that's why 3 - 1
       expect(val.isoWeekday()).to.eql(3 - 1);
     });
 
     it('should round relative to forceNow', function () {
-      const val = dateMath.parse('now-0s/s', undefined, undefined, anchored).format(format);
+      const val = dateMath.parse('now-0s/s', { forceNow: anchored }).format(format);
       expect(val).to.eql(anchored.startOf('s').format(format));
     });
   });
@@ -266,7 +266,7 @@ describe('dateMath', function () {
       const m = momentClone();
       const momentSpy = sinon.spy(moment, 'isMoment');
       const cloneSpy = sinon.spy(m, 'isMoment');
-      dateMath.parse('now', false, m);
+      dateMath.parse('now', { momentInstance: m });
       expect(momentSpy.called).to.be(false);
       expect(cloneSpy.called).to.be(true);
       momentSpy.restore();
@@ -278,12 +278,12 @@ describe('dateMath', function () {
       const m2 = momentClone();
       const m1Spy = sinon.spy(m1, 'isMoment');
       const m2Spy = sinon.spy(m2, 'isMoment');
-      dateMath.parse('now', false, m1);
+      dateMath.parse('now', { momentInstance: m1 });
       expect(m1Spy.called).to.be(true);
       expect(m2Spy.called).to.be(false);
       m1Spy.reset();
       m2Spy.reset();
-      dateMath.parse('now', false, m2);
+      dateMath.parse('now', { momentInstance: m2 });
       expect(m1Spy.called).to.be(false);
       expect(m2Spy.called).to.be(true);
       m1Spy.restore();
@@ -294,7 +294,7 @@ describe('dateMath', function () {
       const m = momentClone();
       const momentSpy = sinon.spy(moment, 'isMoment');
       const cloneSpy = sinon.spy(m, 'isMoment');
-      dateMath.parse('now', false, m);
+      dateMath.parse('now', { momentInstance: m });
       expect(momentSpy.called).to.be(false);
       expect(cloneSpy.called).to.be(true);
       momentSpy.reset();

--- a/test/index.js
+++ b/test/index.js
@@ -81,8 +81,12 @@ describe('dateMath', function () {
       expect(dateMath.parse(string).format(format)).to.eql(mmnt.format(format));
     });
 
-    it('should return the current time if passed now', function () {
+    it(`should return the current time when parsing now`, function () {
       expect(dateMath.parse('now').format(format)).to.eql(now.format(format));
+    });
+
+    it(`should use the forceNow parameter when parsing now`, function () {
+      expect(dateMath.parse('now', undefined, undefined, mmnt).format(format)).to.eql(mmnt.format(format));
     });
   });
 
@@ -111,6 +115,10 @@ describe('dateMath', function () {
 
         it('should return ' + len + span + ' before ' + anchor, function () {
           expect(dateMath.parse(thenEx).format(format)).to.eql(anchored.subtract(len, span).format(format));
+        });
+
+        it('should return ' + len + span + ' before forceNow', function () {
+          expect(dateMath.parse(nowEx, undefined, undefined, anchored).format(format)).to.eql(anchored.subtract(len, span).format(format));
         });
       });
     });
@@ -142,16 +150,22 @@ describe('dateMath', function () {
         it('should return ' + len + span + ' after ' + anchor, function () {
           expect(dateMath.parse(thenEx).format(format)).to.eql(anchored.add(len, span).format(format));
         });
+
+        it('should return ' + len + span + ' after forceNow', function () {
+          expect(dateMath.parse(nowEx, undefined, undefined, anchored).format(format)).to.eql(anchored.add(len, span).format(format));
+        });
       });
     });
   });
 
   describe('rounding', function () {
     let now;
+    let anchored;
 
     beforeEach(function () {
       clock = sinon.useFakeTimers(unix);
       now = moment();
+      anchored = moment(anchor);
     });
 
     afterEach(function () {
@@ -163,18 +177,28 @@ describe('dateMath', function () {
         expect(dateMath.parse('now/' + span).format(format)).to.eql(now.startOf(span).format(format));
       });
 
+      it(`should round now to the beginning of forceNow's ` + span, function () {
+        expect(dateMath.parse('now/' + span, undefined, undefined, anchored).format(format)).to.eql(anchored.startOf(span).format(format));
+      });
+
       it('should round now to the end of the ' + span, function () {
         expect(dateMath.parse('now/' + span, true).format(format)).to.eql(now.endOf(span).format(format));
+      });
+
+      it(`should round now to the end of forceNow's ` + span, function () {
+        expect(dateMath.parse('now/' + span, true, undefined, anchored).format(format)).to.eql(anchored.endOf(span).format(format));
       });
     });
   });
 
   describe('math and rounding', function () {
     let now;
+    let anchored;
 
     beforeEach(function () {
       clock = sinon.useFakeTimers(unix);
       now = moment();
+      anchored = moment(anchor);
     });
 
     it('should round to the nearest second with 0 value', function () {
@@ -222,6 +246,11 @@ describe('dateMath', function () {
       // The end of the range (rounding up) should be the last day of the week (so one day before)
       // our start of the week, that's why 3 - 1
       expect(val.isoWeekday()).to.eql(3 - 1);
+    });
+
+    it('should round relative to forceNow', function () {
+      const val = dateMath.parse('now-0s/s', undefined, undefined, anchored).format(format);
+      expect(val).to.eql(anchored.startOf('s').format(format));
     });
   });
 


### PR DESCRIPTION
Reporting needs a consistent way to stub out the equivalent of `Date.now` when performing datemath. This will allow us to capture the date/time when the report is first requested, and use it later when processing the report to emulate the previous time range.
  