### PR TITLE
Fixing the unitsAsc and unitsDesc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 const units = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'ms'];
-const unitsAsc = [...units].sort((a, b) => moment.duration(1, a).valueOf() - moment.duration(1, b).valueOf());
+const unitsAsc = units;
 const unitsDesc = [...unitsAsc].reverse();
 
 const isDate = d => toString.call(d) === '[object Date]';

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
 
 const units = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'ms'];
-const unitsAsc = units;
-const unitsDesc = [...unitsAsc].reverse();
+const unitsDesc = units;
+const unitsAsc = [...unitsDesc].reverse();
 
 const isDate = d => toString.call(d) === '[object Date]';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
 
 const units = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'ms'];
-const unitsAsc = units.sort((prev, val) => prev - moment.duration(1, val).valueOf());
-const unitsDesc = unitsAsc.reverse();
+const unitsAsc = [...units].sort((a, b) => moment.duration(1, a).valueOf() - moment.duration(1, b).valueOf());
+const unitsDesc = [...unitsAsc].reverse();
 
 const isDate = d => toString.call(d) === '[object Date]';
 

--- a/test/index.js
+++ b/test/index.js
@@ -322,4 +322,14 @@ describe('dateMath', function () {
     });
   });
 
+  describe('units', function () {
+    it('should have units descending for unitsDesc', function () {
+      expect(dateMath.unitsDesc).to.eql(['y', 'M', 'w', 'd', 'h', 'm', 's', 'ms']);
+    });
+
+    it('should have units ascending for unitsAsc', function () {
+      expect(dateMath.unitsAsc).to.eql(["ms", "s", "m", "h", "d", "w", "M", "y"]);
+    });
+  });
+
 });

--- a/test/index.js
+++ b/test/index.js
@@ -328,7 +328,7 @@ describe('dateMath', function () {
     });
 
     it('should have units ascending for unitsAsc', function () {
-      expect(dateMath.unitsAsc).to.eql(["ms", "s", "m", "h", "d", "w", "M", "y"]);
+      expect(dateMath.unitsAsc).to.eql(['ms', 's', 'm', 'h', 'd', 'w', 'M', 'y']);
     });
   });
 


### PR DESCRIPTION
https://github.com/elastic/datemath-js/pull/2 introduced a bug where the unitsAsc and unitsDesc weren't being calculated correctly. `.sort` and `.reverse` operate on the Array in-place, and the sort comparer was comparing strings to integers.