### PR TITLE
Switching to Object.prototype.toString.call for IE11 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const units = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'ms'];
 const unitsDesc = units;
 const unitsAsc = [...unitsDesc].reverse();
 
-const isDate = d => toString.call(d) === '[object Date]';
+const isDate = d => Object.prototype.toString.call(d) === '[object Date]';
 
 const isValidDate = d => isDate(d) && !isNaN(d.valueOf());
 


### PR DESCRIPTION
We can't just use `toString.call(d)` in IE 11, it throws the following error: `TypeError: Invalid calling object`